### PR TITLE
Reduce replication lag threshold

### DIFF
--- a/charts/prometheus-rds-alerts/values.yaml
+++ b/charts/prometheus-rds-alerts/values.yaml
@@ -113,7 +113,7 @@ rules:
       description: '{{ $labels.dbidentifier }} uses {{ printf "%.2g" $value }}% of its disk IOPS'
 
   RDSReplicationLag:
-    expr: rds_replica_lag_seconds{} > 3600
+    expr: rds_replica_lag_seconds{} > 60
     for: 5m
     labels:
       severity: warning


### PR DESCRIPTION
# Objective

Reduce replication lag threshold

# Why

Replication lag above 60s is already an alert

# How

- Reduce replication lag threshold to 60s by default

# Release plan

- [ ] Merge this PR