### PR TITLE
Fix additionalRuleLabels default type

### DIFF
--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -1,5 +1,5 @@
 global:
-  additionalRuleLabels: []
+  additionalRuleLabels: {}
 
 defaultRunbookUrl: https://qonto.github.io/database-monitoring-framework/{{chartVersion}}/runbooks/postgresql/{{alertName}}
 rulesGroupName: postgresql.rules

--- a/charts/prometheus-rds-alerts/values.yaml
+++ b/charts/prometheus-rds-alerts/values.yaml
@@ -1,5 +1,5 @@
 global:
-  additionalRuleLabels: []
+  additionalRuleLabels: {}
 
 defaultRunbookUrl: https://qonto.github.io/database-monitoring-framework/{{chartVersion}}/runbooks/rds/{{alertName}}
 rulesGroupName: rds.rules


### PR DESCRIPTION
# Objective

Fix `additionalRuleLabels` default type

# Why

Helm report warnings when `additionalRuleLabels` is customized due to incorrect default variable type.

```
coalesce.go:289: warning: destination for prometheus-rules.prometheus-postgresql-alerts-chart.global.additionalRuleLabels is a table. Ignoring non-table value ([])
coalesce.go:289: warning: destination for prometheus-rules.prometheus-rds-alerts-chart.global.additionalRuleLabels is a table. Ignoring non-table value ([])
```

# How

- Use `dict` as default value for `additionalRuleLabels`

# Release plan

- [ ] Merge this PR
- [ ] Apply with CI