### PR TITLE
Add missing metrics alerts

### DIFF
--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -15,6 +15,15 @@ rules:
       summary: "Exporter is down"
       description: "{{ $labels.instance }} exporter is down"
 
+  PostgreSQLExporterErrors:
+    expr: max(last_over_time(pg_exporter_last_scrape_error[10m])) by (job) > 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Exporter is reporting scraping errors"
+      description: "{{ $labels.job }} is reporting scraping errors. Some metrics are not collected anymore"
+
   PostgreSQLExporterScrapingLimit:
     expr: avg_over_time(pg_exporter_last_scrape_duration_seconds{}[10m]) > 30
     for: 5m

--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -15,6 +15,15 @@ rules:
       summary: "Exporter is down"
       description: "{{ $labels.instance }} exporter is down"
 
+  PostgreSQLExporterMissingScrapeErrorMetric:
+    expr: absent(postgres_exporter_last_scrape_error)
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "PostgreSQL exporter last scrape error metric is missing"
+      description: "PostgreSQL exporter last scrape error metric is missing. Either the exporter is down or some metrics are not collected anymore"
+
   PostgreSQLExporterErrors:
     expr: max(last_over_time(pg_exporter_last_scrape_error[10m])) by (job) > 0
     for: 5m

--- a/content/runbooks/postgresql/PostgreSQLExporterErrors.md
+++ b/content/runbooks/postgresql/PostgreSQLExporterErrors.md
@@ -1,0 +1,27 @@
+---
+title: Exporter Errors
+---
+
+# PostgreSQLExporterErrors
+
+## Meaning
+
+Alert is triggered when the PostgreSQL exporter reports errors when scrapping metrics.
+
+## Impact
+
+The monitoring system is degraded, some metrics may not be collected anymore. Alerts relying on these metrics will not trigger.
+
+## Diagnosis
+
+**Look at Prometheus PostgreSQL exporter logs**. The error messages (`level=error`) should explain why the exporter can't scrape metrics.
+
+Usually, this is linked to misconfiguration of the exporter.
+
+## Mitigation
+
+Identify and fix the exporter misconfigurations.
+
+## Additional resources
+
+- <https://github.com/prometheus-community/postgres_exporter>

--- a/content/runbooks/postgresql/PostgreSQLExporterMissingScrapeErrorMetric.md
+++ b/content/runbooks/postgresql/PostgreSQLExporterMissingScrapeErrorMetric.md
@@ -1,0 +1,25 @@
+---
+title: Exporter missing scrape error metric
+---
+
+# PostgreSQLExporterMissingScrapeErrorMetric
+
+## Meaning
+
+Alert is triggered when Prometheus doesn't collect the last scrape error metric for the Prometheus PostgreSQL exporter.
+
+## Impact
+
+Monitoring system is degraded. The exporter is either down or failing to expose some metrics.
+
+## Diagnosis
+
+1. Check Prometheus PostgreSQL exporter logs
+
+## Mitigation
+
+Identify and fix the errors reported by the exporter.
+
+## Additional resources
+
+- <https://github.com/prometheus-community/postgres_exporter>


### PR DESCRIPTION
The goal of this MR is to create two new alerts for the PostgreSQL exporter, aiming at detecting when the exporter is up, but is not scrapping properly. Such errors may indicate that some metrics are not being exposed or collected properly, resulting in a degraded monitoring system.