### PR TITLE
feat(rds): RDSReplicaLag bumped to 5 min

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .hugo_build.lock
+.DS_Store
 
 resources
 public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Database Monitoring Framework uses GitHub to manage reviews of pull requests.
 
-* If you are a new contributor. See: [Steps to Contribute](#steps-to-contribute)
+* If you are a new contributor, see: [Steps to Contribute](#steps-to-contribute)
 
 * If you have a trivial fix or improvement, go ahead and create a pull request
 

--- a/charts/prometheus-rds-alerts/values.yaml
+++ b/charts/prometheus-rds-alerts/values.yaml
@@ -113,7 +113,7 @@ rules:
       description: '{{ $labels.dbidentifier }} uses {{ printf "%.2g" $value }}% of its disk IOPS'
 
   RDSReplicationLag:
-    expr: rds_replica_lag_seconds{} > 60
+    expr: rds_replica_lag_seconds{} > 300
     for: 5m
     labels:
       severity: warning


### PR DESCRIPTION
AWS documentation mention that if no user transactions are running on the source DB instance, the associated PostgreSQL read replica reports a replication lag of up to five minutes.