### PR TITLE
fix(postgresql): use correct `pg_exporter_last_scrape_error` metric

### DIFF
--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -16,7 +16,7 @@ rules:
       description: "{{ $labels.instance }} exporter is down"
 
   PostgreSQLExporterMissingScrapeErrorMetric:
-    expr: absent(postgres_exporter_last_scrape_error)
+    expr: absent(pg_exporter_last_scrape_error)
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
This MR fixes the metric named used in the newly introduced `PostgreSQLExporterMissingScrapeErrorMetric`alert.