### PR TITLE
Upgrade Hugo to 0.120.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       group: "pages" # Allow one concurrent deployment
       cancel-in-progress: true
     env:
-      HUGO_VERSION: 0.115.4
+      HUGO_VERSION: 0.120.4
       BASE_URL: https://qonto.github.io/database-monitoring-framework
     environment:
       name: github-pages

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,8 @@
 version: '3.1'
 services:
   hugo:
-      image: klakegg/hugo:0.111.0-ext-ubuntu
-      command: server -D --poll 700ms
+      image: hugomods/hugo:${HUGO_VERSION-git-0.120.4}
+      command: hugo server -D --bind 0.0.0.0 --poll 700ms
       volumes:
         - ".:/src"
       ports:

--- a/docs/hugo-upgrade.md
+++ b/docs/hugo-upgrade.md
@@ -1,0 +1,27 @@
+# Hugo upgrade
+
+[Hugo](https://github.com/gohugoio/hugo) engine is frequently updated by the team to add features or bug fixes.
+
+Here is the process to upgrade Hugo:
+
+1. Test new Hugo version locally
+
+    1. Launch Hugo with new version:
+
+        ```bash
+        export HUGO_VERSION=<new_version>
+        docker compose up
+        ```
+
+    1. Check website rendering on <http://localhost:1313>
+
+        Checklist:
+
+        - Check runbook (including SQL rendering) in runbook (e.g. `PostgreSQLInactiveLogicalReplicationSlot` runbook)
+        - Check tabs are correctly rendered in tutorials (e.g. `RDS exporter deployment`)
+        - Check search engine
+        - Check "last update" information in page footer
+
+1. Upgrade Hugo version for local development environment in `docker-compose.yaml`
+
+1. Upgrade Hugo version for CI in `.github/workflows/release.yaml`


### PR DESCRIPTION
# Objective

Upgrade Hugo to 0.120.4

# Why

Use latest bug fixes

# How

- Bump Hugo version in Github workflow
- Use `hugomods/hugo` docker image for local development

# Release plan

- [ ] Merge this PR