### PR TITLE
Reduce the severity of the RDSNonCPUUtilization alert

### DIFF
--- a/charts/prometheus-rds-alerts/prometheus_tests/RDSNonCPUUtilization.yml
+++ b/charts/prometheus-rds-alerts/prometheus_tests/RDSNonCPUUtilization.yml
@@ -22,7 +22,7 @@ tests:
                       aws_account_id: 111111111111
                       aws_region: eu-west-3
                       dbidentifier: db1
-                      severity: critical
+                      severity: warning
                   exp_annotations:
                       description: "db1 has 20 non CPU wait"
                       summary: "db1 has high non CPU utilization"

--- a/charts/prometheus-rds-alerts/values.yaml
+++ b/charts/prometheus-rds-alerts/values.yaml
@@ -82,10 +82,10 @@ rules:
       )
     for: 10m
     labels:
-      severity: critical
+      severity: warning
     annotations:
       summary: "{{ $labels.dbidentifier }} has high non CPU utilization"
-      description: "{{ $labels.dbidentifier }} has {{ $value }} non CPU wait"
+      description: '{{ $labels.dbidentifier }} has {{ printf "%.0f" $value }} queries waiting for a reason other than the CPU'
 
   RDSMemoryUtilization:
     expr: |


### PR DESCRIPTION
# Objective

Reduce the severity of the `RDSNonCPUUtilization` alert.

# Why

A poorly configured application could easily trigger this alert if it didn't manage advisory locks correctly.

While RDSNonCPUUtilization is a strong indicator that the system is underperforming, it doesn't justify raising `critical` alerts.

# How

- Set severity from `critical` to `warning`

# Release plan

- [ ] Merge this PR