### PR TITLE
chore(queries): pg_stat_user_tables: skip tables with an AccessExclusiveLock

### DIFF
--- a/content/tutorials/postgresql-exporter.queries.yaml
+++ b/content/tutorials/postgresql-exporter.queries.yaml
@@ -200,28 +200,12 @@ pg_stat_user_tables:
           pg_indexes_size(pg_class.oid)                  AS index_size,
           pg_total_relation_size(pg_class.reltoastrelid) AS toast_size
         FROM
-          pg_stat_user_tables u
-        JOIN pg_class ON pg_class.oid = u.relid AND pg_class.relkind <> 'm' -- exclude matviews to prevent query being locked when refreshing MV
-      UNION ALL
-        SELECT
-          c.oid,
-          SUM(c.relpages::bigint*8192) AS table_size,
-          coalesce(SUM(idx.index_bytes),0) as index_size,
-          coalesce(SUM((c2.relpages+c3.relpages)::bigint*8192),0) AS toast_size
-        FROM pg_stat_user_tables u
-        JOIN pg_class c ON u.relid=c.oid AND c.relkind='m'   -- matviews only
-          LEFT JOIN pg_class c2 ON c2.oid = c.reltoastrelid
-          LEFT JOIN pg_index it ON it.indrelid=c.reltoastrelid  -- only one index per pg_toast table
-          LEFT JOIN pg_class c3 ON c3.oid=it.indexrelid
-          CROSS JOIN LATERAL (
-            SELECT SUM(c4.relpages::bigint*8192) AS index_bytes
-            FROM pg_index i JOIN pg_class c4 ON i.indrelid=c.oid AND c4.oid=i.indexrelid
-          ) idx
-        GROUP BY c.oid
+          pg_stat_user_tables ut
+        JOIN pg_class ON pg_class.oid = ut.relid
+        WHERE NOT EXISTS (
+            SELECT 1 FROM pg_locks WHERE pg_locks.relation = ut.relid AND pg_locks.mode = 'AccessExclusiveLock'
+        )
       ) t ON u.relid = t.oid
-    WHERE NOT EXISTS (
-      SELECT 1 FROM pg_locks WHERE pg_locks.relation = u.relid AND pg_locks.mode = 'AccessExclusiveLock'
-    )
     ;
   metrics:
     - datname:

--- a/content/tutorials/postgresql-exporter.queries.yaml
+++ b/content/tutorials/postgresql-exporter.queries.yaml
@@ -219,6 +219,9 @@ pg_stat_user_tables:
           ) idx
         GROUP BY c.oid
       ) t ON u.relid = t.oid
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_locks WHERE pg_locks.relation = u.relid AND pg_locks.mode = 'AccessExclusiveLock'
+    )
     ;
   metrics:
     - datname:


### PR DESCRIPTION
Methods computing size of tables or related objects (such as `pg_total_relation_size` or `pg_table_size`) acquires an AccessShareLock. This happens while refreshing a Materialized View or when ALTER'ing a table.

A fix has been implemented to estimate (very precisely) the size of materialized views, so the query does not wait while a materialized view is being refreshed. However, this did not fix the issue when a table is being ALTER'ed: the SQL query waits for the AccessExclusiveLock being released, and this can take several minutes. It is an issue because the exporter stops exporting any data while the ALTER is running.

To prevent that, we check in `pg_locks` table if an AccessExclusiveLock exists: if it does exist, we skip it:
- the exporter will compute size for tables with no AccessExclusiveLock locks
- the exporter will not be blocked

This is not perfect: there may have a race condition where the Lock is being acquired just before the query is being executed. However, we believe this should prevent the common cases where an ALTER is run for a long time (several minutes), and we consider having the exporter blocked for a single execution acceptable.