### PR TITLE
Add parameters to customize keep_firing_for Prometheus rule

### DIFF
--- a/charts/_source/templates/_helpers.tpl
+++ b/charts/_source/templates/_helpers.tpl
@@ -71,6 +71,7 @@ Render Prometheus rule
 {{- $name := .name -}}
 {{- $pintComments := default dict .pintComments -}}
 {{- $for := .for -}}
+{{- $keepFiringFor := default .defaultKeepFiringFor .keepFiringFor -}}
 {{- $ruleLabels := .labels -}}
 {{- $record := .record -}}
 {{- $annotations := default dict .annotations -}}
@@ -111,6 +112,9 @@ Render Prometheus rule
   {{- end }}
   {{- if $for }}
   for: {{ $for }}
+  {{- end }}
+  {{- if $keepFiringFor }}
+  keep_firing_for: {{ $keepFiringFor }}
   {{- end }}
 {{- if $labels }}
   labels:

--- a/charts/_source/templates/prometheusConfiguration.yaml
+++ b/charts/_source/templates/prometheusConfiguration.yaml
@@ -7,6 +7,7 @@ groups:
 {{- $_ := set . "globalAdditionalExprLabels" $.Values.global.additionalExprLabels }}
 {{- $_ := set . "globalAdditionalRuleLabels" $.Values.global.additionalRuleLabels }}
 {{- $_ := set . "defaultRunbookUrl" $.Values.defaultRunbookUrl }}
+{{- $_ := set . "defaultKeepFiringFor" $.Values.defaultKeepFiringFor }}
 {{- $_ := set . "chartVersion" $.Chart.Version }}
 
 {{- include "chart.renderPrometheusRule" . | indent 8 -}}

--- a/charts/_source/templates/prometheusRules.yaml
+++ b/charts/_source/templates/prometheusRules.yaml
@@ -19,6 +19,7 @@ spec:
 {{- $_ := set . "globalAdditionalExprLabels" $.Values.global.additionalExprLabels }}
 {{- $_ := set . "globalAdditionalRuleLabels" $.Values.global.additionalRuleLabels }}
 {{- $_ := set . "defaultRunbookUrl" $.Values.defaultRunbookUrl }}
+{{- $_ := set . "defaultKeepFiringFor" $.Values.defaultKeepFiringFor }}
 {{- $_ := set . "chartVersion" $.Chart.Version }}
 
 {{- include "chart.renderPrometheusRule" . | indent 8 -}}

--- a/charts/_source/tests/prometheusRules_test.yaml
+++ b/charts/_source/tests/prometheusRules_test.yaml
@@ -109,3 +109,23 @@ tests:
       - equal:
           path: metadata.labels.prometheus
           value: main
+  - it: render with additional additionalPrometheusRuleLabels
+    templates:
+      - prometheusRules.yaml
+    values:
+      - ./values/with_keepFiringFor.yaml
+    asserts:
+      - equal:
+          path: spec.groups[0].rules[0].expr
+          value: |
+            metric2{} > 100
+      - equal:
+          path: spec.groups[0].rules[0].keep_firing_for
+          value: 2s
+      - equal:
+          path: spec.groups[0].rules[1].expr
+          value: |
+            metric1{} > 42
+      - equal:
+          path: spec.groups[0].rules[1].keep_firing_for
+          value: 1s

--- a/charts/_source/tests/values/with_keepFiringFor.yaml
+++ b/charts/_source/tests/values/with_keepFiringFor.yaml
@@ -1,0 +1,24 @@
+defaultKeepFiringFor: 1s
+
+rulesGroupName: unittest
+
+rules:
+
+  RuleWithDefaultKeepFiringFor:
+    expr: metric1{} > 42
+    for: 10m
+    labels:
+      priority: P1
+    annotations:
+      summary: "Metric 1 is over 42"
+      description: "Metric1 is {{ $value }}"
+
+  RuleWithCustomKeepFiringFor:
+    expr: metric2{} > 100
+    for: 10m
+    keepFiringFor: 2s
+    labels:
+      priority: P1
+    annotations:
+      summary: "Metric 1 is over 100"
+      description: "Metric2 is {{ $value }}"

--- a/charts/_source/values.yaml
+++ b/charts/_source/values.yaml
@@ -2,6 +2,8 @@ global:
   additionalExprLabels: []
   additionalRuleLabels: {}
 
+defaultKeepFiringFor: ""
+
 format: PrometheusRuleCRD
 
 rulesGroupName: default

--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -3,7 +3,9 @@ global:
 
 format: PrometheusRuleCRD
 
+defaultKeepFiringFor: ""
 defaultRunbookUrl: https://qonto.github.io/database-monitoring-framework/{{chartVersion}}/runbooks/postgresql/{{alertName}}
+
 rulesGroupName: postgresql.rules
 
 rules:

--- a/charts/prometheus-rds-alerts/values.yaml
+++ b/charts/prometheus-rds-alerts/values.yaml
@@ -3,7 +3,9 @@ global:
 
 format: PrometheusRuleCRD
 
+defaultKeepFiringFor: ""
 defaultRunbookUrl: https://qonto.github.io/database-monitoring-framework/{{chartVersion}}/runbooks/rds/{{alertName}}
+
 rulesGroupName: rds.rules
 
 additionalPrometheusRuleLabels: {}


### PR DESCRIPTION
# Objective

Add `defaultKeepFiringFor` and `keepFiringFor` parameters to Helm chart and configure `keep_firing_for` attribute.

# Why

Users may need to customize the `keep_firing_for` Prometheus rule parameter for some alerts.

At Qonto, we need this parameter to keep alerts open during Pod rescheduling.

# How

- Add `defaultKeepFiringFor` and `keepFiringFor` Helm parameters

# Release plan

- [ ] Merge this PR