### PR TITLE
fix(alert): fix sql-exporter is Down alert

### DIFF
--- a/charts/prometheus-postgresql-alerts/prometheus_tests/SQLExporterDown.yml
+++ b/charts/prometheus-postgresql-alerts/prometheus_tests/SQLExporterDown.yml
@@ -21,3 +21,19 @@ tests:
                       summary: "Exporter is down"
                       description: "SQL Exporter is down"
                       runbook_url: "https://qonto.github.io/database-monitoring-framework/0.0.0/runbooks/postgresql/SQLExporterDown"
+    - name: SQLExporterDown
+      interval: 1m
+      input_series:
+          - series: 'up{service="sql-exporter", target=""}'
+            values: '0x00'
+      alert_rule_test:
+          - alertname: SQLExporterDown
+            eval_time: 5m
+            exp_alerts:
+                - exp_labels:
+                      service: sql-exporter
+                      severity: critical
+                  exp_annotations:
+                      summary: "Exporter is down"
+                      description: "SQL Exporter is down"
+                      runbook_url: "https://qonto.github.io/database-monitoring-framework/0.0.0/runbooks/postgresql/SQLExporterDown"

--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -11,7 +11,7 @@ rulesGroupName: postgresql.rules
 rules:
 
   SQLExporterDown:
-    expr: absent(up{service="sql-exporter", target=""})
+    expr: absent(up{service="sql-exporter", target=""}) or up{service="sql-exporter", target=""} <1
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
**Why:** only relying on Absent will miss the other case where exporter is down (no targets)
**How:** added alternative check
**Tests:** Ok