### PR TITLE
fix(PostgreSQLLongRunningQuery): removed pid from query to limit spam

### DIFF
--- a/charts/prometheus-postgresql-alerts/prometheus_tests/PostgreSQLLongRunningQuery.yml
+++ b/charts/prometheus-postgresql-alerts/prometheus_tests/PostgreSQLLongRunningQuery.yml
@@ -19,8 +19,7 @@ tests:
                       datname: unittest
                       usename: test
                       severity: warning
-                      pid: 1234
                   exp_annotations:
                       summary: "Long running query on unittest of db1"
-                      description: "test is running a long query on unittest of db1 with pid 1234"
+                      description: "test is running a long query on unittest of db1"
                       runbook_url: "https://qonto.github.io/database-monitoring-framework/0.0.0/runbooks/postgresql/PostgreSQLLongRunningQuery"

--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -78,13 +78,13 @@ rules:
       description: "{{ $labels.slot_name }} on {{ $labels.target }} is inactive"
 
   PostgreSQLLongRunningQuery:
-    expr: max by (target, datname, usename, pid) (pg_active_backend_duration_minutes{usename!=""}) > 30
+    expr: max by (target, datname, usename) (pg_active_backend_duration_minutes{usename!=""}) > 30
     for: 1m
     labels:
       severity: warning
     annotations:
       summary: "Long running query on {{ $labels.datname }} of {{ $labels.target }}"
-      description: "{{ $labels.usename }} is running a long query on {{ $labels.datname }} of {{ $labels.target }} with pid {{ $labels.pid }}"
+      description: "{{ $labels.usename }} is running a long query on {{ $labels.datname }} of {{ $labels.target }}"
     pintComments:
       - disable promql/series
 

--- a/content/runbooks/postgresql/PostgreSQLLongRunningQuery.md
+++ b/content/runbooks/postgresql/PostgreSQLLongRunningQuery.md
@@ -20,6 +20,8 @@ Alert is triggered when a PostgreSQL query runs for an extended period.
 
 ## Diagnosis
 
+1. Find the PID(s) of queries by running `pg_active_backend_duration_minutes{ usename=...,datname=...,target=... }`
+
 1. Open `PostgreSQL server live` dashboard
 
 1. Click on the query to get details


### PR DESCRIPTION
Why: if a single user regularly have multiple long running queries, it spams the alert system, creating alert fatigue. 

How: grouping the alerts around one PID would lessen the spam. 

Consideration: maybe we should also add the "keep firing for" option too. 