### PR TITLE
fix(PostgreSQLMaxConnections): remove value from alert description

### DIFF
--- a/charts/prometheus-postgresql-alerts/prometheus_tests/PostgreSQLMaxConnections.yml
+++ b/charts/prometheus-postgresql-alerts/prometheus_tests/PostgreSQLMaxConnections.yml
@@ -21,5 +21,5 @@ tests:
                       severity: warning
                   exp_annotations:
                       summary: "db1 is close from the maximum database connections"
-                      description: "db1 uses 90% of the maximum database connections"
+                      description: "db1 uses >80% of the maximum database connections"
                       runbook_url: "https://qonto.github.io/database-monitoring-framework/0.0.0/runbooks/postgresql/PostgreSQLMaxConnections"

--- a/charts/prometheus-postgresql-alerts/values.yaml
+++ b/charts/prometheus-postgresql-alerts/values.yaml
@@ -48,7 +48,7 @@ rules:
       severity: warning
     annotations:
       summary: "{{ $labels.target }} is close from the maximum database connections"
-      description: '{{ $labels.target }} uses {{ printf "%.2g" $value }}% of the maximum database connections'
+      description: '{{ $labels.target }} uses >80% of the maximum database connections'
 
   PostgreSQLReplicationSlotStorageLimit:
     expr: max by (target, slot_name) (pg_replication_slots_available_storage_percent{}) < 20


### PR DESCRIPTION
The MR propose a fix to avoid printing actual values to prevent spamming alerting systems with new alerts. Instead, we simplify the description for easy recognition by the alerting system.