### PR TITLE
Fix RDSDiskSpaceLimit link

### DIFF
--- a/content/runbooks/rds/RDSLowDiskSpaceCount.md
+++ b/content/runbooks/rds/RDSLowDiskSpaceCount.md
@@ -20,4 +20,4 @@ The PostgreSQL instance(s) might stop to prevent data corruption if no more disk
    max by (aws_account_id, aws_region, dbidentifier) (rds_free_storage_bytes{} * 100 / rds_allocated_storage_bytes{}) < 20
    ```
 
-1. Refer to [RDSDiskSpaceLimit](RDSDiskSpaceLimit.md) for each of them as it's the same alert just ringing a bit earlier.
+1. Refer to [RDSDiskSpaceLimit]({{< ref "RDSDiskSpaceLimit" >}}) for each of them as it's the same alert just ringing a bit earlier.


### PR DESCRIPTION
In [`RDSLowDiskSpaceCount`][1], we have a link to `RDSDiskSpaceLimit`, but it is broken. This is due how [hugo][2] (which we use to render the documentation) deals with links.

To fix this, we need to use [`ref`][3].

[1]: https://qonto.github.io/database-monitoring-framework/0.2.2/runbooks/rds/RDSLowDiskSpaceCount/
[2]: https://gohugo.io/
[3]: https://gohugo.io/content-management/cross-references/