### PR TITLE
🚀 feat(RDSDiskSpaceLimit.md): add step to request aws admin permissio…

### DIFF
--- a/content/runbooks/rds/RDSDiskSpaceLimit.md
+++ b/content/runbooks/rds/RDSDiskSpaceLimit.md
@@ -78,8 +78,13 @@ You must avoid reaching no disk space left situation.
         ```bash
         export AWS_PROFILE=<AWS account>
         ```
+    2. Request aws admin permissions
 
-    2. Determine the minimum storage for the increase
+        ```
+        qontoctl aws admin get-access "bump $RDS_INSTANCE storage"
+        ```
+
+    3. Determine the minimum storage for the increase
         💡 RDS requires a minimal storage increase of 10%
 
         ```bash
@@ -91,7 +96,7 @@ You must avoid reaching no disk space left situation.
         | jq -r '{"Current IOPS": .DBInstances[0].Iops, "Current Storage Limit": .DBInstances[0].AllocatedStorage, "New minimum storage size": ((.DBInstances[0].AllocatedStorage|tonumber)+(.DBInstances[0].AllocatedStorage|tonumber*0.1|floor))}'
         ```
 
-    3. Increase storage:
+    4. Increase storage:
 
         ```bash
         NEW_ALLOCATED_STORAGE=<replace with new allocated storage in GB>
@@ -104,7 +109,7 @@ You must avoid reaching no disk space left situation.
 
         ❗ If the RDS instance has replicas instances (replica or reporting), you must repeat the operation for all replicas to keep the same configuration between instances
 
-    4. Backport changes in Terraform
+    5. Backport changes in Terraform
 
 ## Additional resources
 

--- a/content/runbooks/rds/RDSDiskSpaceLimit.md
+++ b/content/runbooks/rds/RDSDiskSpaceLimit.md
@@ -78,9 +78,10 @@ You must avoid reaching no disk space left situation.
         ```bash
         export AWS_PROFILE=<AWS account>
         ```
+
     2. Request aws admin permissions
 
-        ```
+        ```bash
         qontoctl aws admin get-access "bump $RDS_INSTANCE storage"
         ```
 


### PR DESCRIPTION
## Why?

- It is possible that your IAM role does not have the necessary permissions to modify the storage of the RDS instance.

So you can get the following error:

```
An error occurred (AccessDenied) when calling the ModifyDBInstance operation: User: arn:aws:sts::xxxx:assumed-role/xxxx is not authorized to perform: rds:ModifyDBInstance on resource: arn:aws:rds:eu-west-3:xxx:db:xxx because no identity-based policy allows the rds:ModifyDBInstance action
```

So that's why we need to request admin permissions first.