### PR TITLE
Add standard and extended support alerts

### DIFF
--- a/charts/prometheus-rds-alerts/prometheus_tests/RDSExtendedSupport.yml
+++ b/charts/prometheus-rds-alerts/prometheus_tests/RDSExtendedSupport.yml
@@ -1,0 +1,114 @@
+rule_files:
+  - ../values.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      # Instance with 89 days remaining (should alert)
+      - series: 'rds_extended_support_engine_remaining_days{aws_account_id="123456789012",aws_region="us-east-1",dbidentifier="db-instance-1"}'
+        values: '89 89 89 89 89 89 89 89 89 89 89 89'
+
+      # Instance with 90 days remaining (should not alert - boundary)
+      - series: 'rds_extended_support_engine_remaining_days{aws_account_id="123456789012",aws_region="us-east-1",dbidentifier="db-instance-2"}'
+        values: '90 90 90 90 90 90 90 90 90 90 90 90'
+
+      # Instance with 30 days remaining (should alert - critical)
+      - series: 'rds_extended_support_engine_remaining_days{aws_account_id="123456789012",aws_region="eu-west-1",dbidentifier="db-instance-3"}'
+        values: '30 30 30 30 30 30 30 30 30 30 30 30'
+
+      # Instance with 180 days remaining (should not alert)
+      - series: 'rds_extended_support_engine_remaining_days{aws_account_id="123456789012",aws_region="us-west-2",dbidentifier="db-instance-4"}'
+        values: '180 180 180 180 180 180 180 180 180 180 180 180'
+
+      # Instance with 0 days remaining (should alert - imminent forced upgrade)
+      - series: 'rds_extended_support_engine_remaining_days{aws_account_id="123456789012",aws_region="ap-southeast-1",dbidentifier="db-instance-5"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0'
+
+      # Instance with 7 days remaining (should alert - very urgent)
+      - series: 'rds_extended_support_engine_remaining_days{aws_account_id="123456789012",aws_region="ap-northeast-1",dbidentifier="db-instance-6"}'
+        values: '7 7 7 7 7 7 7 7 7 7 7 7'
+
+    alert_rule_test:
+      # Test that alert fires after 1 hour (for=1h) for instance with 89 days
+      - eval_time: 61m
+        alertname: RDSExtendedSupport
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "us-east-1"
+              dbidentifier: "db-instance-1"
+            exp_annotations:
+              summary: "db-instance-1 is close to reaching end of AWS extended support period"
+              description: "db-instance-1 has 89 days remaining before end of extended support. Amazon RDS will automatically upgrade your major engine version after this period."
+
+      # Test that alert fires for instance with 30 days
+      - eval_time: 61m
+        alertname: RDSExtendedSupport
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "eu-west-1"
+              dbidentifier: "db-instance-3"
+            exp_annotations:
+              summary: "db-instance-3 is close to reaching end of AWS extended support period"
+              description: "db-instance-3 has 30 days remaining before end of extended support. Amazon RDS will automatically upgrade your major engine version after this period."
+
+      # Test that alert fires for instance with 0 days (imminent forced upgrade)
+      - eval_time: 61m
+        alertname: RDSExtendedSupport
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "ap-southeast-1"
+              dbidentifier: "db-instance-5"
+            exp_annotations:
+              summary: "db-instance-5 is close to reaching end of AWS extended support period"
+              description: "db-instance-5 has 0 days remaining before end of extended support. Amazon RDS will automatically upgrade your major engine version after this period."
+
+      # Test that alert fires for instance with 7 days (very urgent)
+      - eval_time: 61m
+        alertname: RDSExtendedSupport
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "ap-northeast-1"
+              dbidentifier: "db-instance-6"
+            exp_annotations:
+              summary: "db-instance-6 is close to reaching end of AWS extended support period"
+              description: "db-instance-6 has 7 days remaining before end of extended support. Amazon RDS will automatically upgrade your major engine version after this period."
+
+      # Test that alert does NOT fire before 1 hour (for=1h)
+      - eval_time: 59m
+        alertname: RDSExtendedSupport
+        exp_alerts: []
+
+      # Test that instances with >= 90 days do not trigger alert
+      - eval_time: 61m
+        alertname: RDSExtendedSupport
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "us-east-1"
+              dbidentifier: "db-instance-1"
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "eu-west-1"
+              dbidentifier: "db-instance-3"
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "ap-southeast-1"
+              dbidentifier: "db-instance-5"
+          - exp_labels:
+              severity: critical
+              aws_account_id: "123456789012"
+              aws_region: "ap-northeast-1"
+              dbidentifier: "db-instance-6"

--- a/charts/prometheus-rds-alerts/prometheus_tests/RDSStandardSupport.yml
+++ b/charts/prometheus-rds-alerts/prometheus_tests/RDSStandardSupport.yml
@@ -1,0 +1,92 @@
+rule_files:
+  - ../values.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      # Instance with 59 days remaining (should alert)
+      - series: 'rds_standard_support_engine_remaining_days{aws_account_id="123456789012",aws_region="us-east-1",dbidentifier="db-instance-1"}'
+        values: '59 59 59 59 59 59 59 59 59 59 59 59'
+
+      # Instance with 60 days remaining (should not alert - boundary)
+      - series: 'rds_standard_support_engine_remaining_days{aws_account_id="123456789012",aws_region="us-east-1",dbidentifier="db-instance-2"}'
+        values: '60 60 60 60 60 60 60 60 60 60 60 60'
+
+      # Instance with 30 days remaining (should alert)
+      - series: 'rds_standard_support_engine_remaining_days{aws_account_id="123456789012",aws_region="eu-west-1",dbidentifier="db-instance-3"}'
+        values: '30 30 30 30 30 30 30 30 30 30 30 30'
+
+      # Instance with 100 days remaining (should not alert)
+      - series: 'rds_standard_support_engine_remaining_days{aws_account_id="123456789012",aws_region="us-west-2",dbidentifier="db-instance-4"}'
+        values: '100 100 100 100 100 100 100 100 100 100 100 100'
+
+      # Instance with 0 days remaining (should alert - critical case)
+      - series: 'rds_standard_support_engine_remaining_days{aws_account_id="123456789012",aws_region="ap-southeast-1",dbidentifier="db-instance-5"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0 0'
+
+    alert_rule_test:
+      # Test that alert fires after 1 hour (for=1h) for instance with 59 days
+      - eval_time: 61m
+        alertname: RDSStandardSupport
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              aws_account_id: "123456789012"
+              aws_region: "us-east-1"
+              dbidentifier: "db-instance-1"
+            exp_annotations:
+              summary: "db-instance-1 is close to reaching end of AWS standard support period"
+              description: "db-instance-1 has 59 days remaining before end of standard support. Extended Support costs will apply after this period."
+
+      # Test that alert fires for instance with 30 days
+      - eval_time: 61m
+        alertname: RDSStandardSupport
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              aws_account_id: "123456789012"
+              aws_region: "eu-west-1"
+              dbidentifier: "db-instance-3"
+            exp_annotations:
+              summary: "db-instance-3 is close to reaching end of AWS standard support period"
+              description: "db-instance-3 has 30 days remaining before end of standard support. Extended Support costs will apply after this period."
+
+      # Test that alert fires for instance with 0 days (critical case)
+      - eval_time: 61m
+        alertname: RDSStandardSupport
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              aws_account_id: "123456789012"
+              aws_region: "ap-southeast-1"
+              dbidentifier: "db-instance-5"
+            exp_annotations:
+              summary: "db-instance-5 is close to reaching end of AWS standard support period"
+              description: "db-instance-5 has 0 days remaining before end of standard support. Extended Support costs will apply after this period."
+
+      # Test that alert does NOT fire before 1 hour (for=1h)
+      - eval_time: 59m
+        alertname: RDSStandardSupport
+        exp_alerts: []
+
+      # Test that instances with >= 60 days do not trigger alert
+      - eval_time: 61m
+        alertname: RDSStandardSupport
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              aws_account_id: "123456789012"
+              aws_region: "us-east-1"
+              dbidentifier: "db-instance-1"
+          - exp_labels:
+              severity: warning
+              aws_account_id: "123456789012"
+              aws_region: "eu-west-1"
+              dbidentifier: "db-instance-3"
+          - exp_labels:
+              severity: warning
+              aws_account_id: "123456789012"
+              aws_region: "ap-southeast-1"
+              dbidentifier: "db-instance-5"

--- a/charts/prometheus-rds-alerts/values.yaml
+++ b/charts/prometheus-rds-alerts/values.yaml
@@ -204,3 +204,12 @@ rules:
     annotations:
       summary: "RDS instance(s) use(s) a certificate with an expiration date inferior to 15 days"
       description: "{{ $value }} instance(s) of the AWS account ID={{ $labels.aws_account_id}} in region={{ $labels.aws_region }} use(s) a certificate with an expiration date inferior to 15 days"
+
+  RDSStandardSupport:
+    expr: max by (aws_account_id, aws_region, dbidentifier) (rds_standard_support_engine_remaining_days) < 60
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "{{ $labels.dbidentifier }} is close to reaching end of AWS standard support period"
+      description: "{{ $labels.dbidentifier }} has {{ $value }} days remaining before end of standard support. Extended Support costs will apply after this period."

--- a/charts/prometheus-rds-alerts/values.yaml
+++ b/charts/prometheus-rds-alerts/values.yaml
@@ -213,3 +213,12 @@ rules:
     annotations:
       summary: "{{ $labels.dbidentifier }} is close to reaching end of AWS standard support period"
       description: "{{ $labels.dbidentifier }} has {{ $value }} days remaining before end of standard support. Extended Support costs will apply after this period."
+
+  RDSExtendedSupport:
+    expr: max by (aws_account_id, aws_region, dbidentifier) (rds_extended_support_engine_remaining_days) < 90
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "{{ $labels.dbidentifier }} is close to reaching end of AWS extended support period"
+      description: "{{ $labels.dbidentifier }} has {{ $value }} days remaining before end of extended support. Amazon RDS will automatically upgrade your major engine version after this period."

--- a/content/runbooks/rds/RDSExtendedSupport.md
+++ b/content/runbooks/rds/RDSExtendedSupport.md
@@ -1,0 +1,92 @@
+---
+title: Extended Support Close to Expiration
+---
+
+# RDSExtendedSupport
+
+## Meaning
+
+Alert is triggered when an RDS instance is close to reaching the end of AWS extended support period.
+
+## Impact
+
+{{< hint danger >}}
+**Critical**
+
+After extended support ends, AWS will force an automatic upgrade to a supported major engine version. This upgrade will happen during your maintenance window and cannot be prevented. You should upgrade proactively to maintain control over the process and timing.
+{{< /hint >}}
+
+RDS Extended Support is available for up to 3 years past the RDS end of standard support date for a major engine version. After the extended support period ends, Amazon RDS will automatically upgrade your database instance to a supported major engine version during a maintenance window.
+
+Automatic upgrades can cause:
+
+- Unexpected downtime during the upgrade process
+- Application compatibility issues if not properly tested
+- Potential breaking changes in the new major version
+- Loss of control over upgrade timing
+
+## Diagnosis
+
+Identify the instance(s) approaching end of extended support:
+
+- Check the RDS console for engine version and support status
+- Or use the following AWS CLI command to list instances and their engine versions:
+
+  ```bash
+  aws rds describe-db-instances --query 'DBInstances[*].[DBInstanceIdentifier,Engine,EngineVersion]' --output table
+  ```
+
+- Verify the extended support end date for your engine version:
+  - [Amazon RDS for PostgreSQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html)
+  - [Amazon RDS for MySQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html)
+  - [Amazon Aurora PostgreSQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html)
+  - [Amazon Aurora MySQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.html)
+
+## Mitigation
+
+{{< hint warning >}}
+**Important**
+
+Major version upgrades require the `--allow-major-version-upgrade` flag and may involve:
+
+- Longer downtime than minor version upgrades
+- Parameter group compatibility changes
+- Application code modifications
+- Thorough testing before production deployment
+{{< /hint >}}
+
+{{< hint info >}}
+- Use Blue/Green deployments for zero-downtime major version upgrades
+- Consider using AWS Database Migration Service (DMS) for complex migrations
+- Review the upgrade checklist for your specific database engine
+- Test with a copy of production data to identify issues early
+- Plan for rollback procedures in case of issues
+{{< /hint >}}
+
+Upgrade your database engine immediately to avoid automatic forced upgrades:
+
+1. **Identify target version**: Choose a major engine version with active standard support
+2. **Test thoroughly**: Create a snapshot and test the major version upgrade in a non-production environment
+   - Verify application compatibility
+   - Test all critical queries and features
+   - Review breaking changes in the new major version
+3. **Plan the upgrade**: Schedule during a maintenance window with minimal business impact
+4. **Perform the upgrade**:
+
+   ```bash
+   aws rds modify-db-instance \
+       --db-instance-identifier <your_db_instance> \
+       --engine-version <target_major_version> \
+       --allow-major-version-upgrade \
+       --apply-immediately
+   ```
+
+   Or schedule for the next maintenance window by omitting `--apply-immediately`
+
+## Additional resources
+
+- [Amazon RDS Extended Support](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html)
+- [Upgrading a DB instance engine version](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html)
+- [Using Amazon RDS Blue/Green Deployments for database updates](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/blue-green-deployments.html)
+- [Upgrade your Amazon RDS for PostgreSQL or Amazon Aurora PostgreSQL database, Part 1: Comparing upgrade approaches](https://aws.amazon.com/blogs/database/part-1-upgrade-your-amazon-rds-for-postgresql-database-comparing-upgrade-approaches/)
+- [Best practices for upgrading Amazon RDS for MySQL and Amazon RDS for MariaDB](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.MySQL.html)

--- a/content/runbooks/rds/RDSStandardSupport.md
+++ b/content/runbooks/rds/RDSStandardSupport.md
@@ -1,0 +1,73 @@
+---
+title: Standard Support Close to Expiration
+---
+
+# RDSStandardSupport
+
+## Meaning
+
+Alert is triggered when an instance is close to reaching the end of AWS standard support period.
+
+## Impact
+
+{{< hint warning >}}
+**Important**
+
+Extended Support charges are applied automatically once standard support ends. These costs are in addition to your regular RDS instance charges and can substantially increase your monthly bill.
+{{< /hint >}}
+
+After the standard support period ends, AWS will automatically enroll the database engine version into Extended Support, which incurs additional charges. Extended Support provides security patches and critical fixes during a transition window to give you more time to upgrade.
+
+Extended Support costs can be significant and vary by engine type and instance size. Without upgrading, you will continue to pay Extended Support fees until you upgrade to a supported engine version.
+
+## Diagnosis
+
+Identify the instance(s) approaching end of standard support:
+
+- Check the RDS console for engine version information
+- Or use the following AWS CLI command to list instances and their engine versions:
+
+  ```bash
+  aws rds describe-db-instances --query 'DBInstances[*].[DBInstanceIdentifier,Engine,EngineVersion]' --output table
+  ```
+
+- Check the current engine version against AWS documentation to determine the standard support end date:
+  - [Amazon RDS for PostgreSQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html)
+  - [Amazon RDS for MySQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html)
+  - [Amazon Aurora PostgreSQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html)
+  - [Amazon Aurora MySQL versions](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.html)
+
+## Mitigation
+
+{{< hint info >}}
+**Tips**
+
+- Major version upgrades may require application compatibility testing
+- Consider using Blue/Green deployments for zero-downtime upgrades
+- Review the upgrade documentation for your specific engine for breaking changes
+- Use the RDS Extended Support cost calculator to estimate potential charges if you delay the upgrade
+{{< /hint >}}
+
+Plan and execute a database engine upgrade before the standard support period ends:
+
+1. **Review upgrade paths**: Identify the target engine version that has active standard support
+2. **Test the upgrade**: Create a snapshot and test the upgrade in a non-production environment
+3. **Plan the upgrade window**: Schedule the upgrade during a maintenance window with minimal impact
+4. **Perform the upgrade**:
+
+   ```bash
+   aws rds modify-db-instance \
+       --db-instance-identifier <your_db_instance> \
+       --engine-version <target_version> \
+       --apply-immediately
+   ```
+
+   Or schedule it for the next maintenance window by omitting `--apply-immediately`
+
+## Additional resources
+
+- [Amazon RDS Extended Support](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/extended-support.html)
+- [Estimating the charges for Amazon RDS Extended Support](https://aws.amazon.com/blogs/aws-cloud-financial-management/estimating-the-charges-for-amazon-rds-extended-support/)
+- [RDS Calculator for Extended Support costs](https://calculator.aws/#/createCalculator/RDSPostgreSQL)
+- [Upgrade your Amazon RDS for PostgreSQL or Amazon Aurora PostgreSQL database, Part 1: Comparing upgrade approaches](https://aws.amazon.com/blogs/database/part-1-upgrade-your-amazon-rds-for-postgresql-database-comparing-upgrade-approaches/)
+- [Upgrading a DB instance engine version](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Upgrading.html)


### PR DESCRIPTION
# Goal

Add monitoring alerts for RDS database engine support lifecycle to prevent unexpected costs and forced upgrades.

# Why

RDS instances approaching end of standard support automatically incur Extended Support charges, which can significantly increase monthly costs. When Extended Support ends, AWS forces automatic upgrades during maintenance windows, potentially causing unexpected downtime and application compatibility issues. These alerts provide proactive warnings to plan and execute controlled upgrades.

https://github.com/qonto/prometheus-rds-exporter/pull/272 introduced the `rds_extended_support_engine_remaining_days`and `rds_standard_support_engine_remaining_days` new metrics

# How

- Added RDSStandardSupport alert and runbook to warn when instances approach end of standard support (before Extended Support charges begin)
- Added RDSExtendedSupport alert and runbook to warn when instances approach end of extended support (before forced automatic upgrades)

Both runbooks include:

- Clear impact explanations with warning/danger hints
- Diagnosis steps using AWS CLI commands
- Mitigation procedures with upgrade commands
- Links to AWS documentation and upgrade best practices

# Release

Patch release - adds new monitoring capabilities without breaking changes to existing alerts.

